### PR TITLE
Additional tweaks for flash grants.

### DIFF
--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -68,9 +68,9 @@ layout: default
                 </div>
             </div><!-- end row -->
 
-	    <div class="row">
+	    <div class="row fellow-flashgrants-row">
 	      <div class="col-sm-9 col-sm-offset-3">
-		{% assign flashgrants = site.data.flashgrants | where: "fellow", page.fullname | sort: "name" %}
+		{% assign flashgrants = site.data.flashgrants | where: "fellow", page.fullname | sort: "date" | reverse %}
 		{% if flashgrants.size != 0 %}
 		{% include flashgrants_block.html heading="Flash Grant Nominations" items=flashgrants date_fmt="%B %Y" %}
 		{% endif %}

--- a/css/style.css
+++ b/css/style.css
@@ -2617,3 +2617,8 @@ body > .navbar-collapse .navbar-search .btn-primary:hover {
 .flashgrants-row .flashgrants-item {
     margin: 10px 0;
 }
+
+.fellow-flashgrants-row .flashgrants-row h3 {
+    font-size: 25px;
+    margin: 20px 0;
+}

--- a/flashgrants.html
+++ b/flashgrants.html
@@ -28,7 +28,7 @@ title: Flash Grants
 
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2">
-	{% assign by_year = site.data.flashgrants | group_by_year: "date" | sort: "year" %}
+	{% assign by_year = site.data.flashgrants | group_by_year: "date" | sort: "year" | reverse %}
 
 	{% for for_year in by_year %}
 	{% assign items = for_year.items | sort_two: "date", "name" %}


### PR DESCRIPTION
- Reverse chronological order for flash grant lists.
- Reduce fellow page flash grant nominations heading. ``<h4>`` is left-align which did not look great, so I kept it as ``<h3>`` and reduced the font size and top and bottom margins.