### PR TITLE
Remove HTML from category in spend breakdown

### DIFF
--- a/_includes/fellows/spend.html
+++ b/_includes/fellows/spend.html
@@ -217,7 +217,7 @@
 		  '.spend-breakdown-infographic-'+year+
 		  ' .spend-breakdown-segment-'+category;
 	      d3.selectAll(cls).attr('title', function(d, i) {
-		  return category.replace('-', ' ').capitalize()+'<br/>$'+amount.formatMoney();
+		  return category.replace('-', ' ').capitalize()+': $'+amount.formatMoney();
 	      });
 	  };
       };


### PR DESCRIPTION
Hovering over the "spend breakdown" chart shows the category and amount,
separated by a verbatim "<br/>" instead of a newline.  Since HTML can't
be used there and there's enough space to show them on one line, separate
category and amount by a colon instead.