### PR TITLE
Provide redirects for old thinking posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll"
 gem "jekyll-archives"
+gem "jekyll-redirect-from"
 gem "html-proofer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-archives (2.1.1)
       jekyll (>= 2.4)
+    jekyll-redirect-from (0.13.0)
+      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -76,6 +78,7 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-archives
+  jekyll-redirect-from
 
 BUNDLED WITH
    1.13.6

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ breadcrumb_list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
 
 gems:
   - jekyll-archives
+  - jekyll-redirect-from
 
 ##
 # JEKYLL-ARCHIVES

--- a/thinking/_posts/2014-01-15-thinking-openness.md
+++ b/thinking/_posts/2014-01-15-thinking-openness.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-openness 2.jpg"
 image_credit: "opensource.com (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/opensourceway/6555465757"
 on_report: true
+redirect_from:
+  - /thinking/thinking-openness/
 ---
 
 The open source software movement has not only created widely used software but million dollar businesses. Although the model is well established for software development, distribution and use, it is not the case for education, philanthropy, hardware or social development, to name but a few important endeavours. The default imposed on knowledge resources by copyright law is automatic lock down. This default makes little sense if your agenda is social change.

--- a/thinking/_posts/2014-02-16-thinking-traditional-funder-to-today.md
+++ b/thinking/_posts/2014-02-16-thinking-traditional-funder-to-today.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-make-better.jpg"
 image_credit: "Race Bannon (CC BY 2.0)"
 image_source: "https://www.flickr.com/photos/bewareofdog/284783751/"
 on_report: true
+redirect_from:
+  - /thinking/thinking-traditional-funder-to-today/
 ---
 
 Our main goal was to improve the quality of education in South Africa. We invested in projects that offered unique and innovative solutions to educational challenges in a developing society, focused on the areas of science, technology, entrepreneurship and maths in education, as well as propagating the use of open source software. The Foundation operated as a traditional funding agency – we accepted proposals and funded them. Grantees implemented their projects and came back with reports.

--- a/thinking/_posts/2014-02-20-thinking-application-pointers.md
+++ b/thinking/_posts/2014-02-20-thinking-application-pointers.md
@@ -12,6 +12,8 @@ image: "/images/blog/blog-application-pointers 2.jpg"
 image_credit: "Flazingo Photos (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/124247024@N07/14089983055"
 on_report: true
+redirect_from:
+  - /thinking/thinking-application-pointers/
 ---
 
 Prospective applicants often ask us to narrow down the parameters for applications and be more specific about what we’re looking for. We are not planning on doing that, as we want to be surprised and intrigued by applicants, no matter how unconventional the idea may be.

--- a/thinking/_posts/2014-03-03-thinking-open-strategy.md
+++ b/thinking/_posts/2014-03-03-thinking-open-strategy.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-open-strategy 2.jpg"
 image_credit: "Jessica Duensing for opensource.com. (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/opensourceway/6555466069"
 on_report: true
+redirect_from:
+  - /thinking/thinking-open-strategy/
 ---
 
 The more we expose the thinking, working and practices of our organisation, our ideas and our projects, the better. Exposing this information allows other organisations, project implementers, funders, policy makers, change agents, advocates and academics to learn from what we have done.

--- a/thinking/_posts/2014-04-21-thinking-privacy.md
+++ b/thinking/_posts/2014-04-21-thinking-privacy.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-privacy 2.jpg"
 image_credit: "Jean-Pierre Dalbéra (CC BY 2.0)"
 image_source: "https://www.flickr.com/photos/dalbera/6401982701"
 on_report: true
+redirect_from:
+  - /thinking/thinking-privacy/
 ---
 
 We do this because who we are and how we behave has impact on others. We want to present the best, most relevant parts of ourselves in a given context. We choose to ignore the warts and wobbly bits in favour of the identity we’ve claimed as our own in that space. It’s part of being human, being in control of our own lives and choosing what we reveal about ourselves, under what circumstances and when. When privacy is violated, it removes that power and freedom of choice.

--- a/thinking/_posts/2014-05-15-thinking-how-of-open.md
+++ b/thinking/_posts/2014-05-15-thinking-how-of-open.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-how-of-open 2.jpg"
 image_credit: "opensource.com (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/opensourceway/8297629922"
 on_report: true
+redirect_from:
+  - /thinking/thinking-how-of-open/
 ---
 
 This success has also made the term fashionable and sometimes leads to overenthusiastic uses of the open label or, more worryingly, <a title="Open Washing" href="http://blog.okfn.org/2014/03/10/open-washing-the-difference-between-opening-your-data-and-simply-making-them-available/" target="_blank">open-washing</a> . It can result in uncertainty and confusion for those who plan to open up knowledge resources for strategic purposes. The detail of how open is open, matters.

--- a/thinking/_posts/2014-08-26-thinking-fellowship-september-2014.md
+++ b/thinking/_posts/2014-08-26-thinking-fellowship-september-2014.md
@@ -10,6 +10,8 @@ banner: "/images/blog/blog-welcome1.jpg"
 image: "/images/blog/blog-welcome1.jpg"
 image_credit: "Ramesh NG (CC BY-SA 2.0)"
 image_source: "https://secure.flickr.com/photos/rameshng/5930493923/in/photostream/"
+redirect_from:
+  - /thinking/thinking-fellowship-september-2014/
 ---
 
 We had submissions from all over the world, exploring areas of science, education, culture, health, privacy and many many more. We spoke to people working on issues from personal safety to universal access to knowledge, from designing open hardware to alleviating poverty. All of the applications showed passion and personal commitment. We continue to be impressed.

--- a/thinking/_posts/2014-08-26-thinking-peter-bloom.md
+++ b/thinking/_posts/2014-08-26-thinking-peter-bloom.md
@@ -12,6 +12,8 @@ image_credit: "(CC BY-SA 2.0)"
 image_source: "https://secure.flickr.com/photos/18600003544/11776318694"
 videos:
   - //player.vimeo.com/video/92422924
+redirect_from:
+  - /thinking/thinking-peter-bloom/
 ---
 
 Through Rhizomatica, Peter is setting up affordable local mobile phone networks in under-served areas in Mexico.

--- a/thinking/_posts/2014-08-26-thinking-seamus-kraft.md
+++ b/thinking/_posts/2014-08-26-thinking-seamus-kraft.md
@@ -12,6 +12,8 @@ image_credit: "Mike Hiatt (CC BY-NC-SA 2.0)"
 image_source: "https://secure.flickr.com/photos/mfhiatt/5513840452"
 videos:
   - //www.youtube.com/embed/pV96QUil7Ec
+redirect_from:
+  - /thinking/thinking-seamus-kraft/
 ---
 
 <a href="{{ "/fellows/seamus-kraft/" | prepend: site.baseurl }}">Seamus</a> applied to the Foundation to expand his work on the Madison Project which aims to open up government by increasing transparency and citizen participation in policy-making. We have seen a lot of open government applications in the past, and Seamus' is the most practical one by far. He is starting off by focusing on a small scope in a very specific context and is uniquely positioned to implement these first steps thanks to his experience in Washington.

--- a/thinking/_posts/2014-08-26-thinking-sean-bonner.md
+++ b/thinking/_posts/2014-08-26-thinking-sean-bonner.md
@@ -12,6 +12,8 @@ image_credit: "Fumi Yamazaki (CC BY-NC-SA 2.0)"
 image_source: "https://secure.flickr.com/photos/fumi/8050493981"
 videos:
   - //www.youtube.com/embed/2a0eiTsDgI8
+redirect_from:
+  - /thinking/thinking-sean-bonner/
 ---
 
 We are excited about <a href="{{ "/fellows/sean-bonner" | prepend: site.baseurl }}">Sean's</a> work as he is literally putting the tools in the hands of the people who need them, localising the measure-report-decide cycle around environmental risk factors such as radiation and noise pollution.

--- a/thinking/_posts/2014-09-01-thinking-fellowship-exit-2014.md
+++ b/thinking/_posts/2014-09-01-thinking-fellowship-exit-2014.md
@@ -10,6 +10,8 @@ banner: "/images/blog/blog-exit2.jpg"
 image: "/images/blog/blog-exit2.jpg"
 image_credit: "Brent Moore (CC BY-NC 2.0)"
 image_source: "https://secure.flickr.com/photos/brent_nashville/5157879240"
+redirect_from:
+  - /thinking/thinking-fellowship-exit-2014/
 ---
 
 During his three years as a Shuttleworth Fellow, **Arthur Attwell** worked on [Paperight](http://www.paperight.com/), a rights clearance house for literary and educational works to allow distributed, local, on-demand book printing. Access to reading materials is critical to learning in its broadest sense. Arthur's passion is to ensure universal access, with access including at least legal and physical dimensions. Digital is showing promise, but has not yet resulted in the scale needed, and never will if legal access issues are not resolved.

--- a/thinking/_posts/2015-02-06-thinking-legal-agreements.md
+++ b/thinking/_posts/2015-02-06-thinking-legal-agreements.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-legal-agreements2.jpg"
 image_credit: "Alan Levine (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/cogdog/8188824613"
 on_report: true
+redirect_from:
+  - /thinking/thinking-legal-agreements/
 ---
 
 Since 2007 we have required Fellows to apply open licences - first <a title="CC-BY-SA" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC-BY-SA</a> and then <a title="CC-BY" href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC-BY</a> - to all intellectual property created during the fellowship.

--- a/thinking/_posts/2015-02-23-thinking-our-experiment.md
+++ b/thinking/_posts/2015-02-23-thinking-our-experiment.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-TOC.jpg"
 image_credit: "allison (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/look_ma_im_flying_pictures/2222370392"
 on_report: true
+redirect_from:
+  - /thinking/thinking-our-experiment/
 ---
 
 This is not where we started and it is almost certainly not who we will be indefinitely. But our experience in philanthropic investment so far has resulted in a couple of key principles that govern how we behave in the world, and specifically how we structure our relationships with those we invest resources in.

--- a/thinking/_posts/2015-03-05-thinking-fellowship-exit-March-2015.md
+++ b/thinking/_posts/2015-03-05-thinking-fellowship-exit-March-2015.md
@@ -15,6 +15,8 @@ videos:
   - //player.vimeo.com/video/120778543
   - //player.vimeo.com/video/120776490
   - //player.vimeo.com/video/120776491
+redirect_from:
+  - /thinking/thinking-fellowship-exit-March-2015/
 ---
 
 **Catharina Maracke** took on the issue of contributor agreements for free and open source software (FOSS) projects through the Harmony project in March 2012. Where Fellows typically bring their own project into the Fellowship, Catharina was in the unusual position of taking on an existing project with various and varying role players. Hers was a very nuanced role, having to be sensitive to industry and community dynamics.

--- a/thinking/_posts/2015-03-05-thinking-welcome-luke-mustafa.md
+++ b/thinking/_posts/2015-03-05-thinking-welcome-luke-mustafa.md
@@ -12,6 +12,8 @@ image_credit: "Si1very (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/silvery/541254231"
 videos:
   - "//player.vimeo.com/video/120776492"
+redirect_from:
+  - /thinking/thinking-welcome-luke-mustafa/
 ---
 Luka's fellowship is centred around the development of Koruza, a 3D printable wireless optical system for connecting buildings up to 100m apart with internet access.
 

--- a/thinking/_posts/2015-08-03-thinking-welcome-adam-astra-waldo.md
+++ b/thinking/_posts/2015-08-03-thinking-welcome-adam-astra-waldo.md
@@ -10,6 +10,8 @@ description: "We are excited to welcome three new Shuttleworth Fellows on 1 Sept
 image: "/images/blog/blog-new-fellows.jpg"
 image_credit: "Jeff (CC BY-NC-ND 2.0)"
 image_source: "https://www.flickr.com/photos/theboyds/5798422024/"
+redirect_from:
+  - /thinking/thinking-welcome-adam-astra-waldo/
 ---
 Adam Hyde has a particular talent for helping experts codify processes into manuals for the benefit of a wider audience. His started with technologists through [Booksprints](http://www.booksprints.net/)  and has now turned his attention to academics. As someone familiar with, but not ingrained in, the way academic output is captured and shared, he is questioning the journal publishing process at both the conceptual and practical level. How can we increase the value of scientific output to benefit society as a whole? By getting more findings out faster, accompanied by the supporting data and tools, so others can replicate findings and build upon the advances made. However,
 this will require a significant change in the way academics, researchers, administrators, funders and publishers work together. At the policy level there are significant efforts under way. Adam's unique contribution is at the practical level, building the tools and community necessary to support the process of scholarly communication in its re-imagined form.

--- a/thinking/_posts/2015-09-22-thinking-how-we-measure-success.md
+++ b/thinking/_posts/2015-09-22-thinking-how-we-measure-success.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-success-cherry1.jpg"
 image_credit: "Billy Wilson (CC BY-NC 2.0)"
 image_source: "https://www.flickr.com/photos/billy_wilson/4227102330/"
 on_report: true
+redirect_from:
+  - /thinking/thinking-how-we-measure-success/
 ---
 
 Applicants, and sometimes even Fellows, find it difficult to compute the broad question "what do **YOU** want to do?". They keep looking for guidance to narrow down the scope of possibility and fit within prescribed parameters. Yes, we want open and innovative, we like technology and we get excited about access. Other than that, and even beyond that, we want applicants to tell us what they want to do, not the other way round.

--- a/thinking/_posts/2016-02-29-thinking-welcome-aaron-peter-tiffiniy.md
+++ b/thinking/_posts/2016-02-29-thinking-welcome-aaron-peter-tiffiniy.md
@@ -11,6 +11,8 @@ image: "/images/blog/blog-new-fellows-032016.jpg"
 image_credit: "Wiredforlego (CC BY-NC 2.0)"
 image_source: "https://www.flickr.com/photos/wiredforsound23/10750177755/"
 on_report: false
+redirect_from:
+  - /thinking/thinking-welcome-aaron-peter-tiffiniy/
 ---
 __Aaron Makaruk__
 

--- a/thinking/_posts/2016-03-01-thinking-farewell-dan-pmr.md
+++ b/thinking/_posts/2016-03-01-thinking-farewell-dan-pmr.md
@@ -11,6 +11,8 @@ image: "/images/blog/applause.jpg"
 image_credit: "Chris Campbell (CC BY-NC 2.0)"
 image_source: "https://www.flickr.com/photos/cgc/20029265130/"
 on_report: false
+redirect_from:
+  - /thinking/thinking-farewell-dan-pmr/
 ---
 __Dan Whaley__
 

--- a/thinking/_posts/2016-03-17-thinking-Steward-Joi-Ito.md
+++ b/thinking/_posts/2016-03-17-thinking-Steward-Joi-Ito.md
@@ -11,6 +11,8 @@ image: "/images/blog/joi.jpg"
 image_credit: "Joi Ito & Jonathan Moore (CC BY 2.0)"
 image_source: "https://www.flickr.com/photos/joi/459402444/"
 on_report: true
+redirect_from:
+  - /thinking/thinking-Steward-Joi-Ito/
 ---
 At the heart of the Shuttleworth Foundation Fellowship Programme are two key values - openness, and supporting individuals. Inspired by the programme itself, we are evolving how we award Fellowships. Not only will we be selecting  individuals to support, we have selected an individual to help us make that decision for the coming round. We are excited to announce that [Joi Ito](https://en.wikipedia.org/wiki/Joi_Ito) will be the honorary steward of the September 2016 fellowship intake.
 

--- a/thinking/_posts/2016-07-07-thinking-open-lock.md
+++ b/thinking/_posts/2016-07-07-thinking-open-lock.md
@@ -11,6 +11,8 @@ image: "/images/blog/protection.jpg"
 image_credit: "Perspecsys Photos (CC BY-SA 2.0)"
 image_source: "https://www.flickr.com/photos/111692634@N04/11406964255/"
 on_report: true
+redirect_from:
+  - /thinking/thinking-open-lock/
 ---
 Contributors to your open project invest their time and energy because they trust you with their gift to the world. So the challenge is this: How can you keep their trust? Can you seal it in for the long term?
 

--- a/thinking/_posts/2016-07-13-thinking-welcome-achal-isha-ugo.md
+++ b/thinking/_posts/2016-07-13-thinking-welcome-achal-isha-ugo.md
@@ -11,6 +11,8 @@ image: "/images/blog/this_mat.jpg"
 image_credit: "alborzshawn (CC BY 2.0)"
 image_source: "https://www.flickr.com/photos/7502393@N04/"
 on_report: false
+redirect_from:
+  - /thinking/thinking-welcome-achal-isha-ugo/
 ---
 This round saw the addition of an [Honorary Steward](https://shuttleworthfoundation.org/thinking/2016/03/17/thinking-Steward-Joi-Ito/), Joi Ito, making the final selection from the short-list. We are very excited to now announce the three new Fellows who will be joining the Shuttleworth Foundation fellowship programme in September: Achal Prabhala, Isha Datar and Ugo Vallauri.
 

--- a/thinking/_posts/2016-07-14-thinking-eating-our-own-dogfood.md
+++ b/thinking/_posts/2016-07-14-thinking-eating-our-own-dogfood.md
@@ -11,6 +11,8 @@ image: "/images/blog/individual.jpg"
 image_credit: "David Nguyen (CC BY 2.0)"
 image_source: "https://www.flickr.com/photos/dabonguyen/"
 on_report: true
+redirect_from:
+  - /thinking/thinking-eating-our-own-dogfood/
 ---
 Individuals carry their learnings, experiences, passions and hopes for the future with them throughout their lives. Supporting them to work on what is broken in their world and share their approach openly, equips them to continue to affect change far beyond the life of a specific grant.
 

--- a/thinking/_posts/2016-09-01-thinking-fellowship-exit-september2016.md
+++ b/thinking/_posts/2016-09-01-thinking-fellowship-exit-september2016.md
@@ -11,6 +11,8 @@ image: "/images/blog/curiosity.jpg"
 image_credit: "Massimo Variolo (CC BY-NC-ND 2.0)"
 image_source: "https://www.flickr.com/photos/samthesensydreamer/6830019312/"
 on_report: false
+redirect_from:
+  - /thinking/thinking-fellowship-exit-september2016/
 ---
 Daniel Lombraña González has had the maximum of 3 consecutive fellowship years and is ready to take on the world. Waldo Jaquith is moving on after 1 year, having achieved what he set out to do in this year, to take up an opportunity that will expand the reach of his work exponentially.
 

--- a/thinking/_posts/2016-10-03-thinking-open-for-business.md
+++ b/thinking/_posts/2016-10-03-thinking-open-for-business.md
@@ -11,6 +11,8 @@ image: "/images/blog/rock.jpg"
 image_credit: "Christian Heilmann (CC BY 2.0)"
 image_source: "https://www.flickr.com/photos/codepo8/4741532223"
 on_report: true
+redirect_from:
+  - /thinking/thinking-open-for-business/
 ---
 Four years ago, we wouldn't have thought we'd fund a music venture. Like most people, we tend to think musicians are doing fine because there's so much music around. But that's like thinking journalists are fine because there's so much news on TV. When culture is centralised in big, closed silos, we lose diversity, and we lose touch with parts of ourselves that we once treasured. And soon we don't even notice what's gone missing. At best, the soundtracks to our lives become poorer. Far worse, it gets harder for musicians to inspire political and social change. It’s no accident that independent music is associated with more politically and socially outspoken music: big business plays it safe and [rewards those who play for the dominant monoculture](http://www.nytimes.com/2012/10/27/arts/music/billboards-chart-changes-draw-fire.html?_r=0).
 

--- a/thinking/_posts/2016-10-05-thinking-Steward-Cory-Doctorow.md
+++ b/thinking/_posts/2016-10-05-thinking-Steward-Cory-Doctorow.md
@@ -11,6 +11,8 @@ image: "/images/blog/cory.jpg"
 image_credit: "Anna Olthoff (CC BY-SA 2.0)"
 image_source: "https://secure.flickr.com/photos/doctorow/8479773351/in/album-72157622138315932/"
 on_report: true
+redirect_from:
+  - /thinking/thinking-Steward-Cory-Doctorow/
 ---
 The September 2016 Fellowship round was the first for which we invited an Honorary Steward to make the final decision on new Fellows. We had a [brilliant experience](https://shuttleworthfoundation.org/thinking/2016/07/14/thinking-eating-our-own-dogfood/) with Joi Ito. He brought his individual experience and perspective. He also invested considerable time and energy in thoughtful review and reflection on the applications and their contextual environments. The result is [three new Fellows](https://shuttleworthfoundation.org/thinking/2016/07/13/thinking-welcome-achal-isha-ugo/) working in wildly different fields, challenging our thinking as much as the status quo, all with [openness](https://shuttleworthfoundation.org/thinking/2014/01/15/thinking-openness/) at heart.
 


### PR DESCRIPTION
In the past posts within "thinking" were stored as /thinking/post/
whereas now they are under /thinking/year/month/day/post/.  For example,
http://jaisenmathai.com/articles/shuttleworth/ links to
https://shuttleworthfoundation.org/thinking/thinking-fellowship-exit-2014/
which redirects to the homepage now.

Use jekyll-redirect-from to provide redirects for the old posts.  This
is done for posts up to 2016 since the new style was definitely used
as of February 2017 according to archive.org.