### PR TITLE
Fix aspect ratio of cover images

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@
 	  <p class="subtext">by {{ page.author }}, {{ page.date | date:"%-d %B %Y" }}</p>
 
 	  <div class="img-credit">
-	    <img src="{{ page.image | replace: " ", "%20" }}" alt="Featured Image"/>
+	    <img src="{{ page.image | replace: " ", "%20" }}" alt="Featured Image" style="object-fit: cover;"/>
 	    <div class="credit">
 	      {% if page.image_credit %}
 	      Created by {{ page.image_credit }}


### PR DESCRIPTION
This will fix the aspect ratio of the cover images for each post. Basically object-fit, will make them a cover and it will auto-adapt the images to fit the height and width of the div ;-) This will work on mobile as well as on desktop and tablets. @jason check it out before merging it.