### PR TITLE
Fix link to Glia web site

### DIFF
--- a/_fellows/tarek-loubani.md
+++ b/_fellows/tarek-loubani.md
@@ -10,7 +10,7 @@ project:
   description: "The goal of this project is to create high-quality, free/open medical devices to increase availability to all."
 links:
   - type: web
-    url: https://github.com/gliax
+    url: https://glia.org/
     text: Glia
   - type: github
     url: https://github.com/GliaX


### PR DESCRIPTION
Two links (Glia and GitHub) were pointing to the GitHub page rather
than one pointing to the Glia web site.