### PR TITLE
Fix Jekyll deprecation warnings by using the new matching method.

### DIFF
--- a/about/how-we-work.html
+++ b/about/how-we-work.html
@@ -49,7 +49,7 @@ title: The Shuttleworth Foundation - How we work
         workings by publishing audited financial statements, including
         reports on all investments in Fellows and their projects.
       </p>
-      
+
       <h3>Open source software</h3>
       <p>
 	The Foundation subscribes to the ethos embodied in free and
@@ -61,7 +61,7 @@ title: The Shuttleworth Foundation - How we work
         free and open source software in our own initiatives and
         require partners to do the same.
       </p>
-      
+
       <h3>Open resources</h3>
       <p>
 	The Foundation is committed to opening knowledge resources. By
@@ -101,7 +101,7 @@ title: The Shuttleworth Foundation - How we work
       </p>
       <p>
 	If you wish to understand in more detail, please look through
-	our <a href="{% post_url 2015-02-06-thinking-legal-agreements %}">contracts</a>.
+	our <a href="{% post_url /thinking/2015-02-06-thinking-legal-agreements %}">contracts</a>.
       </p>
     </div>
   </div>

--- a/open/index.html
+++ b/open/index.html
@@ -49,20 +49,20 @@ title: Shuttleworth Foundation- Open Philosophy
     <div class="six columns">
       <img src="/images/open-source-world.jpg" alt="An open source world"/>
     </div>
-    
+
     <div class="six columns">
       <p>
         We want to understand whether, and how, applying the ethos,
         processes and licences of the free and open source software
         world to areas outside of software can add value.
       </p>
-      <ul>    
+      <ul>
         <li>
       What are the optimal conditions for innovation towards
       positive social change?
     </li>
         <li>
-      Can <a href="{% post_url 2014-01-15-thinking-openness %}">openness</a> help
+      Can <a href="{% post_url /thinking/2014-01-15-thinking-openness %}">openness</a> help
       provide key building blocks for further innovation?
     </li>
         <li>

--- a/thinking/_posts/2014-08-26-thinking-fellowship-september-2014.md
+++ b/thinking/_posts/2014-08-26-thinking-fellowship-september-2014.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 post_date: 29 August 2014
-tags: 
+tags:
   - announcements
 title: "September 2014 fellowship intake"
 author: SF Team
@@ -19,12 +19,12 @@ We had submissions from all over the world, exploring areas of science, educatio
 We were drawn to initiatives that are at the early stages of development and not yet widely funded, to help unlock innovation and bring new ideas to the  forefront. Out of all of these we chose three we believe have an interesting idea with a novel application, a realistic view of what they can achieve and the skills set to implement it.
 
 On 1 September we welcome:
-		
-- [Peter Bloom]({% post_url 2014-08-26-thinking-peter-bloom %}) - Rhizomatica (Telecommunications)
 
-- [Seamus Kraft]({% post_url 2014-08-26-thinking-seamus-kraft %}) - The Open Gov Foundation (Open Government)
+- [Peter Bloom]({% post_url /thinking/2014-08-26-thinking-peter-bloom %}) - Rhizomatica (Telecommunications)
 
-- [Sean Bonner]({% post_url 2014-08-26-thinking-sean-bonner %}) - Safecast (Citizen Science)
+- [Seamus Kraft]({% post_url /thinking/2014-08-26-thinking-seamus-kraft %}) - The Open Gov Foundation (Open Government)
+
+- [Sean Bonner]({% post_url /thinking/2014-08-26-thinking-sean-bonner %}) - Safecast (Citizen Science)
 
 to the Fellowship program.
 


### PR DESCRIPTION
Jekyll complained about calls to `post_url` using a deprecated matching method. I've updated the relevant calls and got rid of the deprecation warnings.

When posts are organized in subdirectories, one need to include the subdirectory path to the post:
https://jekyllrb.com/docs/liquid/tags/#linking-to-posts.

```
Deprecation: A call to '{% post_url 2014-08-26-thinking-peter-bloom %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.
```