### PR TITLE
Add redirect for old flashgrants location

### DIFF
--- a/fellows/flash-grants.html
+++ b/fellows/flash-grants.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Flash Grants
+redirect_from:
+  - /flashgrants/
 ---
 
 <div class="container">


### PR DESCRIPTION
Commit 289a0bf ("First stage of site refresh.") renamed /flashgrants
to /fellows/flash-grants/.  Put in a redirect since some pages link
to the old location.