### PR TITLE
Fix summary of Aaron Makaruk

### DIFF
--- a/_fellows/aaron-makaruk.md
+++ b/_fellows/aaron-makaruk.md
@@ -3,7 +3,8 @@ title: "Aaron Makaruk"
 layout: fellow-2018
 name: "Aaron Makaruk"
 project:
-    name: "Open designs for sustainable urban farming"
+    name: "AKER Kits and OS Beehives"
+    summary: "Open designs for sustainable urban farming"
 current: false
 type: "Seeding food gardens"
 date:   2015-09-01


### PR DESCRIPTION
https://shuttleworthfoundation.org/fellows/alumni/ showed

{"name"=>"Open designs for sustainable urban farming"}

for Aaron Makaruk because fellows.html expects either
fellow.project.summary to exist or assumes fellow.project to have the
project description, neither of which was the case here.