### PR TITLE
Use calendar year instead of fiscal year

### DIFF
--- a/_includes/fellows/spend.html
+++ b/_includes/fellows/spend.html
@@ -13,7 +13,7 @@
       <p>
 	The figures you see here do not reflect each Fellow’s
 	fellowship year funding, but rather the funds unlocked within
-	our financial year, as the fellowship years start either March
+	each calendar year, as the fellowship years start either March
 	or September and Fellows are not required to spend the
 	available funds proportionately throughout the year.
       </p>


### PR DESCRIPTION
The spending figures are shown per calendar year.  Since the
financial year (fiscal year) of Shuttleworth Foundation is
the calendar year, use the latter terminology since it's
clearer to understand.