### PR TITLE
Don't hardcode application deadline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ intake:
   reopen: 1 August 2021
   current: March 2021
   next: March 2022
-  close: 3 November 2020
+  close: 3 November 2021
   notify: 1 January 2021
 
 exclude: [Makefile, README.md, vendor, Gemfile]

--- a/thinking/_posts/2020-10-23-webinar-faq.md
+++ b/thinking/_posts/2020-10-23-webinar-faq.md
@@ -187,7 +187,7 @@ Further reading:
 ### What is the deadline?
 
 
-The deadline for our next fellowship intake is November 3rd, 2020. We take time zones into consideration and will happily receive applications any time before the end of day [Anywhere on Earth](https://time.is/Anywhere_on_Earth).
+The deadline for our next fellowship intake is {{ site.intake.close }}. We take time zones into consideration and will happily receive applications any time before the end of day [Anywhere on Earth](https://time.is/Anywhere_on_Earth).
 
 
 ### What is the timeline from submission to notification?
@@ -301,4 +301,4 @@ Fellowship Stories:
 
 
 
-REMINDER: Applications for our next fellowship round close on **November 3rd, 2020**.
+REMINDER: Applications for our next fellowship round close on {{ site.intake.close }}.


### PR DESCRIPTION
The webinar FAQs are still going to be relevant in a year, so use the
current application deadline from the config.